### PR TITLE
Fix typo in podcast notebook

### DIFF
--- a/podcasts_with_gpt4o.ipynb
+++ b/podcasts_with_gpt4o.ipynb
@@ -189,7 +189,7 @@
     "1. Define speakers we want and add the content\n",
     "2. Generate a script using GPT-4o with structured outputs\n",
     "2. Process the script and feed to GPT-4o to export the speech\n",
-    "3. Assemble the audio outouts into a single audio file, top and tail with intro/outro idents."
+    "3. Assemble the audio outputs into a single audio file, top and tail with intro/outro idents."
    ]
   },
   {


### PR DESCRIPTION
## Summary
- correct "audio outouts" typo in `podcasts_with_gpt4o.ipynb`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6844d1d016a08329b95d31f9becd1e51