### PR TITLE
Fix duplicate script_data assignment

### DIFF
--- a/podcasts_with_gpt4o.ipynb
+++ b/podcasts_with_gpt4o.ipynb
@@ -552,7 +552,6 @@
     "script = client.beta.chat.completions.parse(**params, response_format=ScriptOutput)\n",
     "\n",
     "#  Parse the JSON content\n",
-    "script_data = script.choices[0].message.parsed.segments\n",
     "\n",
     "from pydub import AudioSegment\n",
     "from pydub.effects import normalize\n",


### PR DESCRIPTION
## Summary
- remove redundant `script_data` assignment from the audio-generation cell

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6844d1de45d08329859ec81473d300b1